### PR TITLE
default value for field 'recordtype'

### DIFF
--- a/schema.xml
+++ b/schema.xml
@@ -341,7 +341,7 @@ replace="all"
     <field name="title_in_hierarchy" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="hierarchy_browse" type="string" indexed="true" stored="false" multiValued="true"/>
     <!-- Used for loading correct record driver -->
-    <field name="recordtype" type="string" indexed="false" stored="true"/>
+    <field name="recordtype" type="string" indexed="false" stored="true" default="default"/>
     <!-- Tracking fields to keep track of oldest and most recent index times -->
     <field name="first_indexed" type="date" indexed="true" stored="true"/>
     <field name="last_indexed" type="date" indexed="true" stored="true"/>


### PR DESCRIPTION
as decided in our last schema workshop, here is the default value "default" for the field 'recordtype'. it should be used, when the field 'fullrecord' is not used.

//cc @fincd, @evelynweiser, @bmuschall, @miku    