### PR TITLE
synced/resolved schema state with internal state

### DIFF
--- a/schema.xml
+++ b/schema.xml
@@ -171,10 +171,9 @@ replace="all"
     <field name="collection" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="building" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <!-- Generic Fields -->
-    <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
-    <!-- field name="format" type="string" indexed="true" stored="true" multiValued="true"/ -->
-    <field name="format" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" termVectors="true"/>
-
+    <field name="language" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="format" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    
     <!-- finc:vufindx -->
     <field name="author_id" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="author_ref" type="textProper" indexed="true" stored="false" multiValued="true"/>

--- a/schema.xml
+++ b/schema.xml
@@ -3,7 +3,7 @@
 /**
  * finc-solr biblio schema
  *
- * Copyright (C) 2016 Leipzig University Library <info@ub.uni-leipzig.de>
+ * Copyright (C) Leipzig University Library <info@ub.uni-leipzig.de>
  *
  * @author   Finc Team <team@finc.info>
  * @license  http://opensource.org/licenses/gpl-2.0.php GNU GPLv2
@@ -37,8 +37,8 @@
     </fieldType>
     <fieldType name="text" class="solr.TextField" positionIncrementGap="100">
       <analyzer type="index">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_de-en-kurz.txt"/>
         <!--<filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_deutsch.txt" enablePositionIncrements="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true"/>-->
@@ -48,8 +48,9 @@
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
       <analyzer type="query">
-        <tokenizer class="solr.WhitespaceTokenizerFactory"/>
-        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="0"/>
+        <tokenizer class="solr.ICUTokenizerFactory"/>
+        <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
+        <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_de-en-kurz.txt"/>
         <!--<filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_deutsch.txt" enablePositionIncrements="true"/>
         <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true"/>-->
@@ -100,7 +101,7 @@
         <filter class="solr.ShingleFilterFactory" maxShingleSize="2" outputUnigrams="false"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
-    </fieldType>      
+    </fieldType>
     <fieldType name="textSort" class="solr.TextField" sortMissingLast="false" omitNorms="true">
       <analyzer>
         <tokenizer class="solr.KeywordTokenizerFactory"/>
@@ -158,8 +159,8 @@ replace="all"
     <fieldType name="date" class="solr.TrieDateField" sortMissingLast="true" omitNorms="true" precisionStep="6"/>
     <fieldType name="random" class="solr.RandomSortField" indexed="true"/>
     <fieldType name="boolean" class="solr.BoolField" sortMissingLast="true" omitNorms="true"/>
-    <!-- finc:oclc_num fieldType name="num" class="solr.TrieLongField" sortMissingLast="true" omitNorms="true"/ -->
-    <!--<fieldType name="date" class="solr.DateField" sortMissingLast="true" omitNorms="true"/>-->
+    <!-- add geo field to handle geographic search and display capabilities -->
+    <fieldType name="geo" class="solr.SpatialRecursivePrefixTreeFieldType" distErrPct="0.025" maxDistErr="0.000009" distanceUnits="degrees"/>
   </types>
   <fields>
     <!-- Required by Solr 4.x -->

--- a/schema.xml
+++ b/schema.xml
@@ -39,9 +39,6 @@
       <analyzer type="index">
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="1" catenateNumbers="1" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_de-en-kurz.txt"/>
-        <!--<filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_deutsch.txt" enablePositionIncrements="true"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true"/>-->
         <filter class="solr.ICUFoldingFilterFactory"/>
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory" language="German2"/>
@@ -51,9 +48,6 @@
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.SynonymFilterFactory" synonyms="synonyms.txt" ignoreCase="true" expand="true"/>
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0" splitOnCaseChange="1"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_de-en-kurz.txt"/>
-        <!--<filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_deutsch.txt" enablePositionIncrements="true"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stopwords.txt" enablePositionIncrements="true"/>-->
         <filter class="solr.ICUFoldingFilterFactory"/>
         <filter class="solr.KeywordMarkerFilterFactory" protected="protwords.txt"/>
         <filter class="solr.SnowballPorterFilterFactory" language="German2"/>
@@ -81,7 +75,6 @@
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.WordDelimiterFilterFactory" generateWordParts="1" generateNumberParts="1" catenateWords="0" catenateNumbers="0" catenateAll="0"/>
         <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_de-en-kurz.txt"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
     </fieldType>
@@ -90,14 +83,12 @@
       <analyzer type="index">
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_de-en-kurz.txt"/>
         <filter class="solr.ShingleFilterFactory" maxShingleSize="2" outputUnigrams="false"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>
       <analyzer type="query">
         <tokenizer class="solr.ICUTokenizerFactory"/>
         <filter class="solr.ICUFoldingFilterFactory"/>
-        <filter class="solr.StopFilterFactory" ignoreCase="true" words="stoppwoerter_de-en-kurz.txt"/>
         <filter class="solr.ShingleFilterFactory" maxShingleSize="2" outputUnigrams="false"/>
         <filter class="solr.RemoveDuplicatesTokenFilterFactory"/>
       </analyzer>

--- a/schema.xml
+++ b/schema.xml
@@ -329,14 +329,18 @@ replace="all"
     <dynamicField name="local_heading_*" type="text" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="local_class_*" type="code" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="udk_raw_*" type="code" indexed="true" stored="true" multiValued="true"/>
-    <dynamicField name="udk_facet_*" type="string" indexed="true" stored="true" multiValued="true"/>
-    <dynamicField name="date_*" type="date" indexed="true" stored="true"/>
-    <dynamicField name="*_date" type="date" indexed="true" stored="true"/>
-    <dynamicField name="*_date_mv" type="date" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="udk_facet_*" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <dynamicField name="*_cns" type="callnumberSearch" indexed="true" stored="true"/>
+    <dynamicField name="*_cns_mv" type="callnumberSearch" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_ct" type="codetokenized" indexed="true" stored="true"/>
+    <dynamicField name="*_ct_mv" type="codetokenized" indexed="true" stored="true" multiValued="true"/>
+    <!-- Dynamic fields for customization without schema modification -->
+    <dynamicField name="*_date" type="date" indexed="true" stored="true" docValues="true"/>
+    <dynamicField name="*_date_mv" type="date" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <dynamicField name="*_isn" type="isn" indexed="true" stored="true"/>
     <dynamicField name="*_isn_mv" type="isn" indexed="true" stored="true" multiValued="true"/>
-    <dynamicField name="*_str" type="string" indexed="true" stored="true"/>
-    <dynamicField name="*_str_mv" type="string" indexed="true" stored="true" multiValued="true"/>
+    <dynamicField name="*_str" type="string" indexed="true" stored="true" docValues="true"/>
+    <dynamicField name="*_str_mv" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <dynamicField name="*_txt" type="text" indexed="true" stored="true"/>
     <dynamicField name="*_txt_mv" type="text" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*_txtF" type="textFacet" indexed="true" stored="true"/>
@@ -345,6 +349,8 @@ replace="all"
     <dynamicField name="*_txtP_mv" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="*_random" type="random"/>
     <dynamicField name="*_boolean" type="boolean" indexed="true" stored="true"/>
+    <dynamicField name="*_geo" type="geo" indexed="true" stored="true" multiValued="false"/>
+    <dynamicField name="*_geo_mv" type="geo" indexed="true" stored="true" multiValued="true"/>
   </fields>
   <uniqueKey>id</uniqueKey>
   <defaultSearchField>allfields</defaultSearchField>

--- a/schema.xml
+++ b/schema.xml
@@ -23,7 +23,7 @@
  *
  */ 
 -->
-<schema name="VuFind Bibliographic Index" version="1.2">
+<schema name="VuFind Bibliographic Index" version="1.6">
   <types>
     <!-- Define fieldType long as it is needed by the _version_ field required by Solr 4.x -->
     <fieldType name="long" class="solr.TrieLongField" precisionStep="0" positionIncrementGap="0"/>

--- a/schema.xml
+++ b/schema.xml
@@ -353,18 +353,13 @@ replace="all"
   <copyField source="allfields" dest="spelling"/>
   <!-- ** Complex, Shingle spelling -->
   <copyField source="author" dest="spellingShingle"/>
-  <copyField source="author2" dest="spellingShingle"/>
-  <copyField source="author_corporate" dest="spellingShingle"/>
-  <copyField source="author_corporate2" dest="spellingShingle"/>
   <copyField source="title" dest="spellingShingle"/>
   <copyField source="contents" dest="spellingShingle"/>
   <copyField source="series" dest="spellingShingle"/>
-  <copyField source="series2" dest="spellingShingle"/>
   <copyField source="topic" dest="spellingShingle"/>
   <!-- CopyFields for Faceting on Text -->
   <copyField source="title_full" dest="title_fullStr"/>
   <copyField source="title_full" dest="title_full_unstemmed"/>
-  <!-- copyField source="author" dest="authorStr"/ -->
   <copyField source="author" dest="author_facet"/>
   <copyField source="author2" dest="author_facet"/>
   <copyField source="author_corporate" dest="author_facet"/>

--- a/schema.xml
+++ b/schema.xml
@@ -197,25 +197,23 @@ replace="all"
     <field name="url" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="thumbnail" type="string" indexed="false" stored="true"/>
     <!-- Catalog Specific Fields -->
-    <field name="lccn" type="string" indexed="true" stored="true"/>
-    <field name="ctrlnum" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="urn" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="lccn" type="string" indexed="true" stored="true" docValues="true"/>
+    <field name="ctrlnum" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="isbn" type="isn" indexed="true" stored="true" multiValued="true"/>
     <field name="issn" type="isn" indexed="true" stored="true" multiValued="true"/>
-    <field name="ismn" type="isn" indexed="true" stored="true" multiValued="true"/>
-    <field name="oclc_num" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="callnumber-first" type="string" indexed="true" stored="true"/>
-    <field name="callnumber-subject" type="string" indexed="true" stored="true"/>
-    <field name="callnumber-label" type="string" indexed="true" stored="true"/>
-    <field name="callnumber-sort" type="string" indexed="true" stored="true"/>
-    <field name="callnumber-raw" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="oclc_num" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="callnumber-first" type="string" indexed="true" stored="true" docValues="true"/>
+    <field name="callnumber-subject" type="string" indexed="true" stored="true" docValues="true"/>
+    <field name="callnumber-label" type="string" indexed="true" stored="true" docValues="true"/>
+    <field name="callnumber-sort" type="string" indexed="true" stored="true" docValues="true"/>
+    <field name="callnumber-raw" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="callnumber-search" type="callnumberSearch" indexed="true" stored="true" multiValued="true"/>
-    <field name="dewey-hundreds" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="dewey-tens" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="dewey-ones" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="dewey-full" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="dewey-sort" type="string" indexed="true" stored="true"/>
-    <field name="dewey-raw" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="dewey-hundreds" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="dewey-tens" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="dewey-ones" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="dewey-full" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="dewey-sort" type="string" indexed="true" stored="true" docValues="true"/>
+    <field name="dewey-raw" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="dewey-search" type="callnumberSearch" indexed="true" stored="true" multiValued="true"/>
     <field name="author2" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="author2_role" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
@@ -228,33 +226,22 @@ replace="all"
     <field name="dateSpan" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="series" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="series2" type="text" indexed="true" stored="true" multiValued="true"/>
-    <field name="series_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="topic" type="text" indexed="true" stored="true" termVectors="true" multiValued="true"/>
-    <field name="topic_id" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="topic_ref" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="topic" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="topic_unstemmed" type="textProper" indexed="true" stored="false" multiValued="true"/>
     <field name="topic_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-    <field name="topic_browse" type="string" indexed="true" stored="false" multiValued="true"/>
-    <field name="author_browse" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="topic_browse" type="string" indexed="true" stored="false" multiValued="true" docValues="true"/>
+    <field name="author_browse" type="string" indexed="true" stored="false" multiValued="true" docValues="true"/>
     <field name="genre" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="genre_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="geographic" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="geographic_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-    <field name="geogr_code" default="not assigned" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-    <field name="geogr_code_person" default="not assigned" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="era" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="era_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-    <field name="footnote" type="text" indexed="true" stored="true" multiValued="true"/>
-    <field name="dissertation_note" type="text" indexed="true" stored="true" multiValued="true"/>
-    <field name="performer_note" type="text" indexed="true" stored="true" multiValued="true"/>
-    <field name="illustrated" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="long_lat" type="textFacet" indexed="true" stored="true" multiValued="false"/>
-    <field name="music_heading" type="text" indexed="true" stored="true" multiValued="true"/>
-    <field name="music_heading_browse" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="film_heading" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-    <field name="rvk_facet" type="code" indexed="true" stored="true" termVectors="true" multiValued="true"/>
-    <field name="rvk_label" type="text" indexed="true" stored="true" multiValued="true"/>
-    <field name="rvk_path" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="illustrated" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <!-- Used for geographic search and display fields -->
+    <field name="long_lat" type="geo" indexed="true" stored="true" multiValued="true"/>
+    <field name="long_lat_display" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="long_lat_label" type="string" indexed="false" stored="true" multiValued="true" docValues="true"/>
     <!-- Container fields (i.e. for describing journal containing an article) -->
     <field name="container_title" type="text" indexed="true" stored="true"/>
     <field name="container_volume" type="text" indexed="true" stored="true"/>
@@ -289,23 +276,39 @@ replace="all"
     <field name="author_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="author_ref" type="textProper" indexed="true" stored="false" multiValued="true"/>
     <field name="barcode" type="code" indexed="true" stored="true" multiValued="true"/>
+    <field name="dissertation_note" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="film_heading" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="finc_class_facet" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="footnote" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="geogr_code" default="not assigned" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="geogr_code_person" default="not assigned" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="imprint" type="string" indexed="false" stored="true" multiValued="false" docValues="true"/>
+    <field name="ismn" type="isn" indexed="true" stored="true" multiValued="true"/>
     <field name="itemdata" type="string" indexed="false" stored="true" docValues="true"/>
     <field name="mega_collection" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="misc_dech1" type="codetokenized" indexed="true" stored="false" multiValued="true"/>
     <field name="multipart_link" type="string" indexed="true" stored="true" multiValued="true" termVectors="true" docValues="true"/>
     <field name="multipart_part" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="multipart_set" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="music_heading_browse" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="music_heading" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="performer_note" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="publishPlace" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="purchase" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="record_id" type="string" indexed="true" stored="true" multiValued="false" termVectors="true" docValues="true"/>
     <field name="rsn" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="rvk_facet" type="code" indexed="true" stored="true" termVectors="true" multiValued="true"/>
+    <field name="rvk_label" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="rvk_path" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="series_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="signatur" type="code" indexed="true" stored="true" multiValued="true"/>
     <field name="source_id" default="error" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <field name="timecode" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="title_orig" type="textProper" indexed="true" stored="true" multiValued="false"/>
     <field name="title_uniform" type="text" indexed="true" stored="true" multiValued="false"/>
+    <field name="topic_id" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="topic_ref" type="text" indexed="true" stored="false" multiValued="true"/>
+    <field name="urn" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="zdb" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <!-- Dynamic fields for customization without schema modification -->
     <dynamicField name="callnumber_*" type="code" indexed="true" stored="true" multiValued="true"/>

--- a/schema.xml
+++ b/schema.xml
@@ -173,25 +173,10 @@ replace="all"
     <!-- Generic Fields -->
     <field name="language" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="format" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="author" type="textProper" indexed="true" stored="true" multiValued="true" termVectors="true"/>
+    <field name="author_role" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="author_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="author_sort" type="string" indexed="true" stored="true" docValues="true"/>
-    
-    <!-- finc:vufind3 -->
-    <field name="author" type="textProper" indexed="true" stored="true" multiValued="true" termVectors="true"/>
-    <field name="author_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="author_role" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="author2" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="author2_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="author2_role" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="author_corporate" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="author_corporate_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="author_corporate_role" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="author_corporate2" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="author_corporate2_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="author_corporate2_role" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="author_additional" type="textProper" indexed="true" stored="true" multiValued="true"/>
-
-
     <field name="title" type="text" indexed="true" termVectors="true" stored="true"/>
     <field name="title_part" type="text" indexed="true" stored="true"/>
     <field name="title_sub" type="text" indexed="true" stored="true"/>
@@ -239,7 +224,11 @@ replace="all"
     <field name="dewey-sort" type="string" indexed="true" stored="true"/>
     <field name="dewey-raw" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="dewey-search" type="callnumberSearch" indexed="true" stored="true" multiValued="true"/>
-
+    <field name="author2" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="author2_role" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="author_corporate" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_corporate_role" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="author_additional" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="dateSpan" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="series" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="series2" type="text" indexed="true" stored="true" multiValued="true"/>
@@ -294,8 +283,14 @@ replace="all"
     <field name="last_indexed" type="date" indexed="true" stored="true" docValues="true" default="NOW"/>
     <!-- finc -->
     <field name="access_facet" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="author2_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_corporate2_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_corporate2_role" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="author_corporate2" type="textProper" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_corporate_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="author_corporate_ref" type="textProper" indexed="true" stored="false" multiValued="true"/>
     <field name="author_id" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="author_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="author_ref" type="textProper" indexed="true" stored="false" multiValued="true"/>
     <field name="barcode" type="code" indexed="true" stored="true" multiValued="true"/>
     <field name="finc_class_facet" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>

--- a/schema.xml
+++ b/schema.xml
@@ -174,16 +174,6 @@ replace="all"
     <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
     <!-- field name="format" type="string" indexed="true" stored="true" multiValued="true"/ -->
     <field name="format" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" termVectors="true"/>
-    <!-- finc -->
-    <field name="signatur" type="code" indexed="true" stored="true" multiValued="true"/>
-    <field name="barcode" type="code" indexed="true" stored="true" multiValued="true"/>
-    <field name="rsn" type="string" indexed="true" stored="true" multiValued="true"/>
-
-    <field name="purchase" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="timecode" type="textFacet" indexed="true" stored="true" multiValued="true"/>
-    <field name="misc_dech1" type="codetokenized" indexed="true" stored="false" multiValued="true"/>
-    <field name="finc_class_facet" default="not assigned" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="zdb" type="string" indexed="true" stored="true" multiValued="false"/>
 
     <!-- finc:vufindx -->
     <field name="author_id" type="string" indexed="true" stored="true" multiValued="true"/>
@@ -310,13 +300,21 @@ replace="all"
     <field name="last_indexed" type="date" indexed="true" stored="true" docValues="true" default="NOW"/>
     <!-- finc -->
     <field name="access_facet" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="barcode" type="code" indexed="true" stored="true" multiValued="true"/>
+    <field name="finc_class_facet" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="itemdata" type="string" indexed="false" stored="true" docValues="true"/>
     <field name="mega_collection" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="misc_dech1" type="codetokenized" indexed="true" stored="false" multiValued="true"/>
     <field name="multipart_link" type="string" indexed="true" stored="true" multiValued="true" termVectors="true" docValues="true"/>
     <field name="multipart_part" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="multipart_set" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="purchase" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="record_id" type="string" indexed="true" stored="true" multiValued="false" termVectors="true" docValues="true"/>
+    <field name="rsn" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="signatur" type="code" indexed="true" stored="true" multiValued="true"/>
     <field name="source_id" default="error" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="timecode" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="zdb" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <!-- Dynamic fields for customization without schema modification -->
     <dynamicField name="callnumber_*" type="code" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="barcode_*" type="code" indexed="true" stored="true" multiValued="true"/>

--- a/schema.xml
+++ b/schema.xml
@@ -307,10 +307,10 @@ replace="all"
     <field name="title_in_hierarchy" type="string" indexed="true" stored="true" multiValued="true"/>
     <field name="hierarchy_browse" type="string" indexed="true" stored="false" multiValued="true"/>
     <!-- Used for loading correct record driver -->
-    <field name="recordtype" type="string" indexed="false" stored="true" default="default"/>
+    <field name="recordtype" default="default" type="string" indexed="false" stored="true" docValues="true"/>
     <!-- Tracking fields to keep track of oldest and most recent index times -->
-    <field name="first_indexed" type="date" indexed="true" stored="true"/>
-    <field name="last_indexed" type="date" indexed="true" stored="true"/>
+    <field name="first_indexed" type="date" indexed="true" stored="true" docValues="true"/>
+    <field name="last_indexed" type="date" indexed="true" stored="true" docValues="true" default="NOW"/>
     <!-- finc -->
     <field name="access_facet" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <field name="itemdata" type="string" indexed="false" stored="true" docValues="true"/>

--- a/schema.xml
+++ b/schema.xml
@@ -159,8 +159,6 @@ replace="all"
     <!-- Core Fields  -->
     <field name="id" type="string" indexed="true" stored="true"/>
     <field name="fullrecord" type="string" indexed="false" stored="true"/>
-    <!-- itemdata: finc deprecated -->
-    <field name="itemdata" type="string" indexed="false" stored="true"/>
     <field name="marc_error" type="string" indexed="false" stored="true" multiValued="true"/>
     <field name="allfields" type="text" indexed="true" stored="false" multiValued="true"/>
     <field name="allfields_unstemmed" type="textProper" indexed="true" stored="false" multiValued="true"/>
@@ -317,6 +315,8 @@ replace="all"
     <!-- Tracking fields to keep track of oldest and most recent index times -->
     <field name="first_indexed" type="date" indexed="true" stored="true"/>
     <field name="last_indexed" type="date" indexed="true" stored="true"/>
+    <!-- finc -->
+    <field name="itemdata" type="string" indexed="false" stored="true" docValues="true"/>
     <!-- Dynamic fields for customization without schema modification -->
     <dynamicField name="callnumber_*" type="code" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="barcode_*" type="code" indexed="true" stored="true" multiValued="true"/>

--- a/schema.xml
+++ b/schema.xml
@@ -177,28 +177,21 @@ replace="all"
     <field name="author_role" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="author_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
     <field name="author_sort" type="string" indexed="true" stored="true" docValues="true"/>
-    <field name="title" type="text" indexed="true" termVectors="true" stored="true"/>
+    <field name="title" type="text" indexed="true" stored="true"/>
+    <field name="title_sort" type="textSort" indexed="true" stored="true"/>
     <field name="title_part" type="text" indexed="true" stored="true"/>
     <field name="title_sub" type="text" indexed="true" stored="true"/>
     <field name="title_short" type="text" indexed="true" stored="true"/>
     <field name="title_full" type="text" indexed="true" stored="true"/>
     <field name="title_full_unstemmed" type="textProper" indexed="true" stored="true"/>
-    <field name="title_fullStr" type="string" indexed="true" stored="true"/>
+    <field name="title_fullStr" type="string" indexed="true" stored="true" docValues="true"/>
     <field name="title_auth" type="text" indexed="true" stored="true"/>
-    <field name="title_alt" type="text" indexed="true" stored="true" multiValued="true"/>
-    <field name="title_old" type="text" indexed="true" stored="true" multiValued="true"/>
-    <field name="title_new" type="text" indexed="true" stored="true" multiValued="true"/>    
-    <field name="title_uniform" type="text" indexed="true" stored="true" multiValued="false"/>
-    <field name="title_sort" type="textSort" indexed="true" stored="true"/>
-    <field name="title_orig" type="textProper" indexed="true" stored="true" multiValued="false"/>
-    <field name="physical" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="physical" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="publisher" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="publisherStr" type="string" indexed="true" stored="false" multiValued="true"/>
-    <field name="publishDate" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="publishDateSort" type="string" indexed="true" stored="true"/>
-    <field name="publishPlace" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="imprint" type="string" indexed="false" stored="true" multiValued="false"/>
-    <field name="edition" type="string" indexed="true" stored="true"/>
+    <field name="publisherStr" type="string" indexed="true" stored="false" multiValued="true" docValues="true"/>
+    <field name="publishDate" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="publishDateSort" type="string" indexed="true" stored="true" docValues="true"/>
+    <field name="edition" type="string" indexed="true" stored="true" docValues="true"/>
     <field name="description" type="text" indexed="true" stored="true"/>
     <field name="contents" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="url" type="string" indexed="false" stored="true" multiValued="true"/>
@@ -229,7 +222,10 @@ replace="all"
     <field name="author_corporate" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="author_corporate_role" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="author_additional" type="textProper" indexed="true" stored="true" multiValued="true"/>
-    <field name="dateSpan" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="title_alt" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="title_old" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="title_new" type="text" indexed="true" stored="true" multiValued="true"/>
+    <field name="dateSpan" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="series" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="series2" type="text" indexed="true" stored="true" multiValued="true"/>
     <field name="series_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
@@ -294,18 +290,22 @@ replace="all"
     <field name="author_ref" type="textProper" indexed="true" stored="false" multiValued="true"/>
     <field name="barcode" type="code" indexed="true" stored="true" multiValued="true"/>
     <field name="finc_class_facet" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="imprint" type="string" indexed="false" stored="true" multiValued="false" docValues="true"/>
     <field name="itemdata" type="string" indexed="false" stored="true" docValues="true"/>
     <field name="mega_collection" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="misc_dech1" type="codetokenized" indexed="true" stored="false" multiValued="true"/>
     <field name="multipart_link" type="string" indexed="true" stored="true" multiValued="true" termVectors="true" docValues="true"/>
     <field name="multipart_part" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="multipart_set" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="publishPlace" type="textProper" indexed="true" stored="true" multiValued="true"/>
     <field name="purchase" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="record_id" type="string" indexed="true" stored="true" multiValued="false" termVectors="true" docValues="true"/>
     <field name="rsn" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="signatur" type="code" indexed="true" stored="true" multiValued="true"/>
     <field name="source_id" default="error" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <field name="timecode" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="title_orig" type="textProper" indexed="true" stored="true" multiValued="false"/>
+    <field name="title_uniform" type="text" indexed="true" stored="true" multiValued="false"/>
     <field name="zdb" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <!-- Dynamic fields for customization without schema modification -->
     <dynamicField name="callnumber_*" type="code" indexed="true" stored="true" multiValued="true"/>

--- a/schema.xml
+++ b/schema.xml
@@ -167,13 +167,9 @@ replace="all"
     <field name="spelling" type="textSpell" indexed="true" stored="true" multiValued="true"/>
     <field name="spellingShingle" type="textSpellShingle" indexed="true" stored="true" multiValued="true"/>
     <!-- Institutional Fields -->
-    <field name="access_facet" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="mega_collection" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="record_id" type="string" indexed="true" stored="true" multiValued="false" termVectors="true"/>
-    <field name="source_id" default="error" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="institution" default="finc" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="collection" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="building" type="string" indexed="true" stored="true" multiValued="true"/>
+    <field name="institution" default="finc" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="collection" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="building" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <!-- Generic Fields -->
     <field name="language" type="string" indexed="true" stored="true" multiValued="true"/>
     <!-- field name="format" type="string" indexed="true" stored="true" multiValued="true"/ -->
@@ -316,7 +312,11 @@ replace="all"
     <field name="first_indexed" type="date" indexed="true" stored="true"/>
     <field name="last_indexed" type="date" indexed="true" stored="true"/>
     <!-- finc -->
+    <field name="access_facet" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <field name="itemdata" type="string" indexed="false" stored="true" docValues="true"/>
+    <field name="mega_collection" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="record_id" type="string" indexed="true" stored="true" multiValued="false" termVectors="true" docValues="true"/>
+    <field name="source_id" default="error" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <!-- Dynamic fields for customization without schema modification -->
     <dynamicField name="callnumber_*" type="code" indexed="true" stored="true" multiValued="true"/>
     <dynamicField name="barcode_*" type="code" indexed="true" stored="true" multiValued="true"/>

--- a/schema.xml
+++ b/schema.xml
@@ -173,14 +173,9 @@ replace="all"
     <!-- Generic Fields -->
     <field name="language" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="format" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="author_facet" type="textFacet" indexed="true" stored="true" multiValued="true"/>
+    <field name="author_sort" type="string" indexed="true" stored="true" docValues="true"/>
     
-    <!-- finc:vufindx -->
-    <field name="author_id" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="author_ref" type="textProper" indexed="true" stored="false" multiValued="true"/>
-    <field name="author_corporate_ref" type="textProper" indexed="true" stored="false" multiValued="true"/>
-    <field name="author_facet" type="textFacet" indexed="true" stored="false" multiValued="true"/>
-    <field name="author_sort" type="string" indexed="true" stored="true"/>
-
     <!-- finc:vufind3 -->
     <field name="author" type="textProper" indexed="true" stored="true" multiValued="true" termVectors="true"/>
     <field name="author_orig" type="textProper" indexed="true" stored="true" multiValued="true"/>
@@ -299,6 +294,9 @@ replace="all"
     <field name="last_indexed" type="date" indexed="true" stored="true" docValues="true" default="NOW"/>
     <!-- finc -->
     <field name="access_facet" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="author_corporate_ref" type="textProper" indexed="true" stored="false" multiValued="true"/>
+    <field name="author_id" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="author_ref" type="textProper" indexed="true" stored="false" multiValued="true"/>
     <field name="barcode" type="code" indexed="true" stored="true" multiValued="true"/>
     <field name="finc_class_facet" default="not assigned" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
     <field name="itemdata" type="string" indexed="false" stored="true" docValues="true"/>

--- a/schema.xml
+++ b/schema.xml
@@ -293,19 +293,16 @@ replace="all"
     <field name="container_start_page" type="text" indexed="true" stored="true"/>
     <field name="container_reference" type="text" indexed="true" stored="true"/>
     <!-- Hierarchy Fields -->
-    <field name="multipart_set" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="multipart_link" type="string" indexed="true" stored="true" multiValued="true" termVectors="true"/>
-    <field name="multipart_part" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="hierarchytype" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="hierarchy_top_id" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="hierarchy_top_title" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="hierarchy_parent_id" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="hierarchy_parent_title" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="hierarchy_sequence" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="is_hierarchy_id" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="is_hierarchy_title" type="string" indexed="true" stored="true" multiValued="false"/>
-    <field name="title_in_hierarchy" type="string" indexed="true" stored="true" multiValued="true"/>
-    <field name="hierarchy_browse" type="string" indexed="true" stored="false" multiValued="true"/>
+    <field name="hierarchytype" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="hierarchy_top_id" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="hierarchy_top_title" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="hierarchy_parent_id" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="hierarchy_parent_title" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="hierarchy_sequence" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="is_hierarchy_id" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="is_hierarchy_title" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
+    <field name="title_in_hierarchy" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="hierarchy_browse" type="string" indexed="true" stored="false" multiValued="true" docValues="true"/>
     <!-- Used for loading correct record driver -->
     <field name="recordtype" default="default" type="string" indexed="false" stored="true" docValues="true"/>
     <!-- Tracking fields to keep track of oldest and most recent index times -->
@@ -315,6 +312,9 @@ replace="all"
     <field name="access_facet" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <field name="itemdata" type="string" indexed="false" stored="true" docValues="true"/>
     <field name="mega_collection" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="multipart_link" type="string" indexed="true" stored="true" multiValued="true" termVectors="true" docValues="true"/>
+    <field name="multipart_part" type="string" indexed="true" stored="true" multiValued="true" docValues="true"/>
+    <field name="multipart_set" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <field name="record_id" type="string" indexed="true" stored="true" multiValued="false" termVectors="true" docValues="true"/>
     <field name="source_id" default="error" type="string" indexed="true" stored="true" multiValued="false" docValues="true"/>
     <!-- Dynamic fields for customization without schema modification -->


### PR DESCRIPTION
I tried to sync/resolve the schema state with the internal state of the schema by keeping Solr 5.5 compability. Thereby, I tried to create a bunch of small, (hopefully) consumable commits that should illustrate single steps of this transition. The overall goal was and still is to keep this repository still as the main reference for the (technical) finc Solr schema.

This pull request includes (at least):

- all previously applied/included pull requests
- the internal fields reordering
- the fields enhancements (docvalues etc.) 
- overall stopwords filter removal
- solr schema version increment
- field types update from standard VuFind Solr schema
- dynamic fields update from standard VuFind Solr schema
- copy fields update from standard VuFind Solr schema

I guess this PR can only be merged locally and afterwards it can be pushed via "git push -f" to the remote repositories (since I cleaned the commit history from [this (probably accidentally created) commit](https://github.com/finc/index/commit/dd979a9e2a5610a87bf81a0cd32dfae55208e315)).